### PR TITLE
Use recovery utility for backup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE := $(or ${IMAGE},quay.io/redhat_ztp/openshift-ai-image-backup:latest)
 GIT_REVISION := $(shell git rev-parse HEAD)
 CONTAINER_BUILD_PARAMS = --label git_revision=${GIT_REVISION}
 
-all: build build-image push-image
+all: build build-image
 .PHONY: all
 
 # Include the library makefile
@@ -33,11 +33,11 @@ build:
 	hack/build-go.sh
 .PHONY: build
 
-build-image:
+build-image: build
 	$(CONTAINER_COMMAND) build $(CONTAINER_BUILD_PARAMS) -f Dockerfile . -t $(IMAGE)
 .PHONY:
 
-push-image:
+push-image: build-image
 	$(CONTAINER_COMMAND) push ${IMAGE}
 
 .PHONY: build

--- a/bindata/recovery/upgrade-recovery.sh
+++ b/bindata/recovery/upgrade-recovery.sh
@@ -175,15 +175,11 @@ function take_backup {
     fi
 
     echo "##### $(date -u): Backing up container images, cluster, and required files"
-    # Note: The cluster-restore script uses a hardcoded path for manifests-stopped dir
-    rm -rf ${BACKUP_DIR} /home/core/assets/manifests-stopped
 
-    mkdir -p ${BACKUP_DIR}
-
-    time for id in $(crictl images -o json | jq -r '.images[].id'); do
-        mkdir -p ${BACKUP_DIR}/containers/$id
-        /usr/bin/skopeo copy --all --insecure-policy containers-storage:$id dir:${BACKUP_DIR}/containers/$id
-    done
+    #time for id in $(crictl images -o json | jq -r '.images[].id'); do
+    #    mkdir -p ${BACKUP_DIR}/containers/$id
+    #    /usr/bin/skopeo copy --all --insecure-policy containers-storage:$id dir:${BACKUP_DIR}/containers/$id
+    #done
 
     /usr/local/bin/cluster-backup.sh ${BACKUP_DIR}/cluster
     if [ $? -ne 0 ]; then
@@ -273,13 +269,13 @@ function restore_images_and_files {
     #
     # Restore container images
     #
-    if [ "${SKIP_IMAGE_RESTORE}" = "no" ]; then
-        echo "##### $(date -u): Restoring container images"
-        time for id in $(find ${BACKUP_DIR}/containers -mindepth 1 -maxdepth 2 -type d); do
-            /usr/bin/skopeo copy dir:$id containers-storage:local/$(basename $id)
-        done
-        echo "##### $(date -u): Completed restoring container images"
-    fi
+    #if [ "${SKIP_IMAGE_RESTORE}" = "no" ]; then
+    #    echo "##### $(date -u): Restoring container images"
+    #    time for id in $(find ${BACKUP_DIR}/containers -mindepth 1 -maxdepth 2 -type d); do
+    #        /usr/bin/skopeo copy dir:$id containers-storage:local/$(basename $id)
+    #    done
+    #    echo "##### $(date -u): Completed restoring container images"
+    #fi
 
     #
     # Restore /usr/local content

--- a/internal/recovery_assets/bindata.go
+++ b/internal/recovery_assets/bindata.go
@@ -220,15 +220,11 @@ function take_backup {
     fi
 
     echo "##### $(date -u): Backing up container images, cluster, and required files"
-    # Note: The cluster-restore script uses a hardcoded path for manifests-stopped dir
-    rm -rf ${BACKUP_DIR} /home/core/assets/manifests-stopped
 
-    mkdir -p ${BACKUP_DIR}
-
-    time for id in $(crictl images -o json | jq -r '.images[].id'); do
-        mkdir -p ${BACKUP_DIR}/containers/$id
-        /usr/bin/skopeo copy --all --insecure-policy containers-storage:$id dir:${BACKUP_DIR}/containers/$id
-    done
+    #time for id in $(crictl images -o json | jq -r '.images[].id'); do
+    #    mkdir -p ${BACKUP_DIR}/containers/$id
+    #    /usr/bin/skopeo copy --all --insecure-policy containers-storage:$id dir:${BACKUP_DIR}/containers/$id
+    #done
 
     /usr/local/bin/cluster-backup.sh ${BACKUP_DIR}/cluster
     if [ $? -ne 0 ]; then
@@ -318,13 +314,13 @@ function restore_images_and_files {
     #
     # Restore container images
     #
-    if [ "${SKIP_IMAGE_RESTORE}" = "no" ]; then
-        echo "##### $(date -u): Restoring container images"
-        time for id in $(find ${BACKUP_DIR}/containers -mindepth 1 -maxdepth 2 -type d); do
-            /usr/bin/skopeo copy dir:$id containers-storage:local/$(basename $id)
-        done
-        echo "##### $(date -u): Completed restoring container images"
-    fi
+    #if [ "${SKIP_IMAGE_RESTORE}" = "no" ]; then
+    #    echo "##### $(date -u): Restoring container images"
+    #    time for id in $(find ${BACKUP_DIR}/containers -mindepth 1 -maxdepth 2 -type d); do
+    #        /usr/bin/skopeo copy dir:$id containers-storage:local/$(basename $id)
+    #    done
+    #    echo "##### $(date -u): Completed restoring container images"
+    #fi
 
     #
     # Restore /usr/local content


### PR DESCRIPTION
Restructured launchBackup.go to use the recovery utility to take the
backup, rather than having the individual steps in code. This means
the recovery utility script is a single point of implementation for
both the backup and recovery steps.

Signed-off-by: Don Penney <dpenney@redhat.com>