### PR TITLE
Update workflow event triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,8 @@
 ---
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Updated workflow triggers to drop the branch specification, so checks
are run on developer branches as well as main. Also added
workflow_dispatch event to allow for manually triggered checks.

Signed-off-by: Don Penney <dpenney@redhat.com>