### PR TITLE
Add markdownlint to linter tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,3 +55,13 @@ jobs:
       run: python -m pip install bashate
     - name: Run bashate
       run: make check-bashate
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Markdown Lint
+      uses: ruzickap/action-my-markdown-linter@v1
+      with:
+        config_file: .markdownlint.yaml
+        exclude: vendor/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,240 @@
+# Original .markdownlint.yaml from:
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+
+# Default state for all rules
+default: true
+
+# Path to configuration file to extend
+extends: null
+
+# MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+MD001: false
+
+# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
+MD002:
+  # Heading level
+  level: 1
+
+# MD003/heading-style/header-style - Heading style
+MD003:
+  # Heading style
+  style: "consistent"
+
+# MD004/ul-style - Unordered list style
+MD004:
+  # List style
+  style: "consistent"
+
+# MD005/list-indent - Inconsistent indentation for list items at the same level
+MD005: true
+
+# MD006/ul-start-left - Consider starting bulleted lists at the beginning of the line
+MD006: true
+
+# MD007/ul-indent - Unordered list indentation
+MD007:
+  # Spaces for indent
+  indent: 2
+  # Whether to indent the first level of the list
+  start_indented: false
+  # Spaces for first level indent (when start_indented is set)
+  start_indent: 2
+
+# MD009/no-trailing-spaces - Trailing spaces
+MD009:
+  # Spaces for line break
+  br_spaces: 2
+  # Allow spaces for empty lines in list items
+  list_item_empty_lines: false
+  # Include unnecessary breaks
+  strict: false
+
+# MD010/no-hard-tabs - Hard tabs
+MD010:
+  # Include code blocks
+  code_blocks: true
+  # Number of spaces for each hard tab
+  spaces_per_tab: 1
+
+# MD011/no-reversed-links - Reversed link syntax
+MD011: true
+
+# MD012/no-multiple-blanks - Multiple consecutive blank lines
+MD012:
+  # Consecutive blank lines
+  maximum: 1
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 120
+  # Number of characters for headings
+  heading_line_length: 80
+  # Number of characters for code blocks
+  code_block_line_length: 80
+  # Include code blocks
+  code_blocks: false
+  # Include tables
+  tables: false
+  # Include headings
+  headings: true
+  # Include headings
+  headers: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+
+# MD014/commands-show-output - Dollar signs used before commands without showing output
+MD014: true
+
+# MD018/no-missing-space-atx - No space after hash on atx style heading
+MD018: true
+
+# MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+MD019: true
+
+# MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+MD020: true
+
+# MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+MD021: true
+
+# MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+MD022:
+  # Blank lines above heading
+  lines_above: 1
+  # Blank lines below heading
+  lines_below: 1
+
+# MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+MD023: true
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024:
+  # Only check sibling headings
+  allow_different_nesting: false
+  # Only check sibling headings
+  siblings_only: false
+
+# MD025/single-title/single-h1 - Multiple top-level headings in the same document
+MD025:
+  # Heading level
+  level: 1
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD026/no-trailing-punctuation - Trailing punctuation in heading
+MD026:
+  # Punctuation characters
+  punctuation: ".,;:!。，；：！"
+
+# MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+MD027: true
+
+# MD028/no-blanks-blockquote - Blank line inside blockquote
+MD028: true
+
+# MD029/ol-prefix - Ordered list item prefix
+MD029:
+  # List style
+  style: "one_or_ordered"
+
+# MD030/list-marker-space - Spaces after list markers
+MD030:
+  # Spaces for single-line unordered list items
+  ul_single: 1
+  # Spaces for single-line ordered list items
+  ol_single: 1
+  # Spaces for multi-line unordered list items
+  ul_multi: 1
+  # Spaces for multi-line ordered list items
+  ol_multi: 1
+
+# MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+MD031:
+  # Include list items
+  list_items: true
+
+# MD032/blanks-around-lists - Lists should be surrounded by blank lines
+MD032: true
+
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allowed elements
+  allowed_elements: [br]
+
+# MD034/no-bare-urls - Bare URL used
+MD034: true
+
+# MD035/hr-style - Horizontal rule style
+MD035:
+  # Horizontal rule style
+  style: "consistent"
+
+# MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+MD036:
+  # Punctuation characters
+  punctuation: ".,;:!?。，；：！？"
+
+# MD037/no-space-in-emphasis - Spaces inside emphasis markers
+MD037: true
+
+# MD038/no-space-in-code - Spaces inside code span elements
+MD038: true
+
+# MD039/no-space-in-links - Spaces inside link text
+MD039: true
+
+# MD040/fenced-code-language - Fenced code blocks should have a language specified
+MD040: true
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 1
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD042/no-empty-links - No empty links
+MD042: true
+
+# MD043/required-headings/required-headers - Required heading structure
+MD043:
+  # List of headings
+  headings: null
+  # List of headings
+  headers: null
+
+# MD044/proper-names - Proper names should have the correct capitalization
+MD044:
+  # List of proper names
+  names: []
+  # Include code blocks
+  code_blocks: true
+
+# MD045/no-alt-text - Images should have alternate text (alt text)
+MD045: true
+
+# MD046/code-block-style - Code block style
+MD046:
+  # Block style
+  style: "consistent"
+
+# MD047/single-trailing-newline - Files should end with a single newline character
+MD047: true
+
+# MD048/code-fence-style - Code fence style
+MD048:
+  # Code fence style
+  style: "consistent"
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049:
+  # Emphasis style should be consistent
+  style: "consistent"
+
+# MD050/strong-style - Strong style should be consistent
+MD050:
+  # Strong style should be consistent
+  style: "consistent"

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,36 +1,60 @@
+# Developing in openshift-ai-image-backup
+
 ## Makefile targets
+
 To see all `make` targets, run `make help`
 
-## Updates to bindata:
-When updating files in the `bindata` directory, you will need to regenerate the corresponding go code by running:<br>`make update-bindata`
+## Updates to bindata
+
+When updating files in the `bindata` directory, you will need to regenerate the corresponding go code by running:<br>
+`make update-bindata`
 
 ## Linter tests
-As of this writing, three linters are used by the `make check` command, as well as by the configured github workflow actions:
+
+As of this writing, four linters are used by the `make check` command, as well as by the configured github workflow
+actions:
+
 * golangci-lint
 * shellcheck
 * bashate
+* markdownlint
 
-These tests will be run automatically as a github action when you push an update. Failures can mean your pull request will not be approved. It is suggested that you run `make check` regularly as part of development.
+These tests will be run automatically as a github action when you push an update. Failures can mean your pull request
+will not be approved. It is suggested that you run `make check` regularly as part of development.
 
 ### golangci-lint
-Install golangci-lint in your GO environment by running:<br>`go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.0`
 
-For more information, see:<br>https://golangci-lint.run/usage/install/
+Install golangci-lint in your GO environment by running:<br>
+`go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.0`
+
+For more information, see:<br><https://golangci-lint.run/usage/install/>
 
 ### shellcheck
-ShellCheck provides warnings and suggestions for bash scripts. For information on installing, see:<br>https://github.com/koalaman/shellcheck#installing
+
+ShellCheck provides warnings and suggestions for bash scripts. For information on installing, see:<br>
+<https://github.com/koalaman/shellcheck#installing>
 
 Example:<br>`dnf install ShellCheck`
 
 ### bashate
-Bashate is a style checker for bash scripts. For more information, see:<br>https://github.com/openstack/bashate
+
+Bashate is a style checker for bash scripts. For more information, see:<br><https://github.com/openstack/bashate>
 
 To install:<br>`pip install bashate`
 
+### markdownlint
+
+Markdownlint is a style checker and linter for Markdown files. For more information, see:<br>
+<https://github.com/igorshubovych/markdownlint-cli>
+
+To install:<br>`npm install -g markdownlint-cli`
+
 ## GO formatting
+
 GO has automated formatting. To update code and ensure it is formatted properly, run:<br>`make update-gofmt`
 
 ## Building image
+
 You can build the golang binary itself by running:<br>`hack/build-go.sh`
 
 To build the image, without pushing, just run `make` with no target.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ push-image: build-image
 
 .PHONY: build
 
-check: | verify golangci-lint check-shellcheck check-bashate
+check: | verify golangci-lint check-shellcheck check-bashate check-markdownlint
 .PHONY: check
 
 golangci-lint:
@@ -70,5 +70,15 @@ check-bashate:
 		| xargs -0 --no-run-if-empty bashate -e 'E*' -i E006
 endif
 .PHONY: check-bashate
+
+ifeq ($(shell which markdownlint 2>/dev/null),)
+check-markdownlint:
+	@echo "Skipping markdownlint: Not installed"
+else
+check-markdownlint:
+	find . -name '*.md' -not -path './vendor/*' -not -path './git/*' -print0 \
+		| xargs -0 --no-run-if-empty markdownlint
+endif
+.PHONY: check-markdownlint
 
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # openshift-ai-image-backup
-This repository provides a Dockerfile which builds the go binary in the image. The image can be locally build and pushed to **https://quay.io/repository/redhat_ztp/openshift-ai-image-backup**.
 
-## Build:
+This repository provides a Dockerfile which builds the go binary in the image. The image can be locally build and pushed
+to **<https://quay.io/repository/redhat_ztp/openshift-ai-image-backup>**.
+
+## Build
 
 To build the golang binary, run **./hack/build-go.sh**
 
 ## Kubernetes job
 
-Below kubernetes job can be launched to start the backup procedure from the spoke cluster. To run this task from the hub, you need a cluster-admin role, or can create a service account and adding the proper security context to it and pass **serviceAccountName** to the below job.
+Below kubernetes job can be launched to start the backup procedure from the spoke cluster. To run this task from the
+hub, you need a cluster-admin role, or can create a service account and adding the proper security context to it and
+pass **serviceAccountName** to the below job.
 
-```
+```yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -41,13 +45,14 @@ spec:
 
 ## Launch the backup from hub with manage cluster action
 
-To launch this job as managed cluster action from the hub, one need to create a namespace, service account, clusterrolebinding and the job using managed cluster action:
+To launch this job as managed cluster action from the hub, one need to create a namespace, service account,
+clusterrolebinding and the job using managed cluster action:
 
 For example:
 
-**namespace.yaml**
+#### namespace.yaml
 
-```
+```yaml
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -64,10 +69,9 @@ spec:
         name: backupresource
 ```
 
+#### serviceAccount.yaml
 
-**serviceAccount.yaml**
-
-```
+```yaml
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -86,8 +90,9 @@ spec:
 
 ```
 
-**clusterrolebinding.yaml**
-```
+#### clusterrolebinding.yaml
+
+```yaml
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -113,9 +118,9 @@ spec:
 
 ```
 
+#### k8sJob.yaml
 
-**k8sJob.yaml**
-```
+```yaml
 apiVersion: action.open-cluster-management.io/v1beta1
 kind: ManagedClusterAction
 metadata:
@@ -160,14 +165,17 @@ spec:
                   path: /
                   type: Directory
                 name: backup
-
 ```
 
 ## Recovery from Upgrade Failure
-### Platform Rollback
-Platform rollback, if needed, is handled by issuing the `rpm-ostree rollback -r` command. Not all upgrades will include an update to the platform OS, however, so this step will not always be required.
 
-When the backup was taken, the active deployment was pinned and standby deployments removed. Use the `ostree admin status` command to see the current state.
+### Platform Rollback
+
+Platform rollback, if needed, is handled by issuing the `rpm-ostree rollback -r` command. Not all upgrades will include
+an update to the platform OS, however, so this step will not always be required.
+
+When the backup was taken, the active deployment was pinned and standby deployments removed. Use the
+`ostree admin status` command to see the current state.
 
 |Deployment Status|Rollback Action|
 |-----------------|---------------|
@@ -176,13 +184,15 @@ When the backup was taken, the active deployment was pinned and standby deployme
 |Multiple standby deployments, pinned deployment is not "rollback"|1. Delete unpinned standby deployments with `ostree admin undeploy 1`, until pinned deployment is "rollback".<br>2. Trigger rollback with `rpm-ostree rollback -r` command|
 
 ### Recovery Utility
+
 The upgrade recovery utility is generated when taking the backup, before the upgrade starts, written as `/var/recovery/upgrade-recovery.sh`.
 
 The first phase of the recovery will run the following steps, and then stop to allow the user to reboot the node:
+
 * Shut down `crio.service` and `kubelet.service`, wiping existing containers
 * Restore files from the backup to `/etc`, `/usr/local`, and `/var/lib/kubelet`
 * Restore any additional machine-config managed files from the backup, if applicable
-* Disable `kubelet.service `to prevent it from automatically starting after the reboot
+* Disable `kubelet.service` to prevent it from automatically starting after the reboot
 
 Reboot the node when prompted, with `systemctl reboot`.
 
@@ -190,10 +200,12 @@ The second phase of the recovery can be run after the reboot, with the `--resume
 `/var/recovery/upgrade-recovery.sh --resume`
 
 This phase will do the following:
+
 * Restore the etcd cluster, waiting for required containers to restart
 * Re-enable kubelet.service, so that it launches automatically on subsequent reboots
-* Redeploy etcd, kubeapiserver, kubecontrollermanager, and kubescheduler, waiting for successful redeployment of each, per cluster restore procedure documented at:<br>
-https://docs.openshift.com/container-platform/4.9/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html
+* Redeploy etcd, kubeapiserver, kubecontrollermanager, and kubescheduler, waiting for successful redeployment of each,
+  per cluster restore procedure documented at:<br>
+<https://docs.openshift.com/container-platform/4.9/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html>
 
 Should the recovery utility fail, the user can retry with the `--restart` option:<br>
 `/var/recovery/upgrade-recovery.sh --restart`


### PR DESCRIPTION
Added markdownlint check to Makefile and github workflow to validate
changes to markdown files, and resolved existing lint warnings in
README.md and HACKING.md.

Signed-off-by: Don Penney <dpenney@redhat.com>