### PR TITLE
Remove centos build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,14 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
 ENV GOFLAGS=-mod=mod
 WORKDIR /go/src/github.com/redhat-ztp/openshift-ai-image-backup
-
 # Bring in the go dependencies before anything else so we can take
 # advantage of caching these layers in future builds.
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
-
 COPY . .
 RUN make build
 
-FROM quay.io/centos/centos:stream8
-
-ENV CRICTL_VERSION="v1.22.0"
-
-RUN yum -y install skopeo wget jq
-
-RUN useradd skopeo
-
-# Setup skopeo's uid/guid entries
-RUN echo skopeo:100000:65536 > /etc/subuid
-RUN echo skopeo:100000:65536 > /etc/subgid
-
-# install crictl
-
-RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz \
-         && tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/bin \
-         && rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
-
-
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /go/src/github.com/redhat-ztp/openshift-ai-image-backup/bin/openshift-ai-image-backup /usr/bin/openshift-ai-image-backup
-
-# Point to the Authorization file
-ENV REGISTRY_AUTH_FILE=/tmp/auth.json
-
 ENTRYPOINT ["/usr/bin/openshift-ai-image-backup"]


### PR DESCRIPTION
This commit removes centos build and leaves only go builder for the
Dockerfile's in order to slim down the image.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
