### PR TITLE
Fix directory argument in call to recovery utility

### DIFF
--- a/cmd/launchBackup.go
+++ b/cmd/launchBackup.go
@@ -102,7 +102,7 @@ func LaunchBackup(BackupPath string) error {
 	log.Info("Upgrade recovery script written")
 
 	// Take backup
-	backupCmd := fmt.Sprintf("%s --take-backup %s", scriptname, BackupPath)
+	backupCmd := fmt.Sprintf("%s --take-backup --dir %s", scriptname, BackupPath)
 	err = ExecuteCmd(backupCmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
The call to the recovery utility when taking a backup was missing the
--dir option, so the utility was not processing the specified backup
path properly. As a result, it would always use the default path.

Signed-off-by: Don Penney <dpenney@redhat.com>